### PR TITLE
Update: Adapt to synchronous adapt-schemas API

### DIFF
--- a/docs/plugins/schemas-reference.js
+++ b/docs/plugins/schemas-reference.js
@@ -1,9 +1,4 @@
 export default class SchemasReference {
-  constructor (appData, config, dir, utils) {
-    this.appData = appData
-    this.utils = utils
-  }
-
   async run () {
     this.schemas = await this.loadSchemas()
     this.manualFile = 'schemas-reference.md'
@@ -12,7 +7,7 @@ export default class SchemasReference {
   }
 
   async loadSchemas () {
-    const { schemas, raw } = this.appData.schemas
+    const { schemas, raw } = this.app.schemas
     return Object.keys(schemas)
       .sort((a, b) => a.localeCompare(b))
       .reduce((m, s) => Object.assign(m, { [s]: raw[s] }), {})

--- a/lib/JsonSchemaModule.js
+++ b/lib/JsonSchemaModule.js
@@ -33,7 +33,7 @@ class JsonSchemaModule extends AbstractModule {
     this._library.on('schemaExtended', (base, ext) => this.log('verbose', 'EXTEND_SCHEMA', base, ext))
     this._library.on('reset', () => this.log('debug', 'RESET_SCHEMAS'))
 
-    await this._library.init()
+    this._library.init()
 
     this._library.addKeyword({
       keyword: 'isDirectory',
@@ -122,8 +122,8 @@ class JsonSchemaModule extends AbstractModule {
   /**
    * Empties the schema registry (with the exception of the base schema)
    */
-  async resetSchemaRegistry () {
-    await this._library.resetSchemaRegistry()
+  resetSchemaRegistry () {
+    this._library.resetSchemaRegistry()
   }
 
   /**
@@ -152,14 +152,17 @@ class JsonSchemaModule extends AbstractModule {
    * @return {Promise}
    */
   async registerSchemas (options = {}) {
-    await this.resetSchemaRegistry()
+    this.resetSchemaRegistry()
     await Promise.all(Object.values(this.app.dependencies).map(async d => {
       if (d.name === this.name) return
       const files = await glob('schema/*.schema.json', { cwd: d.rootDir, absolute: true })
-      const results = await Promise.allSettled(files.map(f => this.registerSchema(f)))
-      results
-        .filter(r => r.status === 'rejected')
-        .forEach(r => this.log('warn', r.reason))
+      for (const f of files) {
+        try {
+          this.registerSchema(f)
+        } catch (e) {
+          this.log('warn', e)
+        }
+      }
     }))
     await this.registerSchemasHook.invoke()
     if (options.quiet !== true) this.logSchemas()
@@ -170,11 +173,11 @@ class JsonSchemaModule extends AbstractModule {
    * @param {String} filePath Path to the schema file
    * @param {Object} options Extra options
    * @param {Boolean} options.replace Replace existing schema with same name
-   * @return {Promise<Schema>}
+   * @return {Schema}
    */
-  async registerSchema (filePath, options = {}) {
+  registerSchema (filePath, options = {}) {
     try {
-      return await this._library.registerSchema(filePath, options)
+      return this._library.registerSchema(filePath, options)
     } catch (e) {
       // Convert library errors to app errors
       if (e instanceof SchemaError) {
@@ -199,7 +202,7 @@ class JsonSchemaModule extends AbstractModule {
    * Creates a new Schema instance
    * @param {String} filePath Path to the schema file
    * @param {Object} options Options passed to Schema constructor
-   * @returns {Promise<Schema>}
+   * @returns {Schema}
    */
   createSchema (filePath, options = {}) {
     return this._library.createSchema(filePath, {
@@ -228,7 +231,7 @@ class JsonSchemaModule extends AbstractModule {
   async getSchema (schemaName, options = {}) {
     await this._schemasRegistered
     try {
-      return await this._library.getSchema(schemaName, options)
+      return this._library.getSchema(schemaName, options)
     } catch (e) {
       if (e instanceof SchemaError && e.code === 'MISSING_SCHEMA') {
         throw this.app.errors.MISSING_SCHEMA.setData({ schemaName })

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "repository": "github:adapt-security/adapt-authoring-jsonschema",
   "dependencies": {
     "adapt-authoring-core": "^2.0.0",
-    "adapt-schemas": "^2.0.0"
+    "adapt-schemas": "^3.1.0"
   },
   "peerDependencies": {
     "adapt-authoring-config": "^1.1.4",

--- a/tests/JsonSchemaModule.spec.js
+++ b/tests/JsonSchemaModule.spec.js
@@ -85,9 +85,9 @@ describe('JsonSchemaModule', () => {
   })
 
   describe('#resetSchemaRegistry()', () => {
-    it('should call the library resetSchemaRegistry', async () => {
+    it('should call the library resetSchemaRegistry', () => {
       const { instance, mockSchemas } = createInstance()
-      await instance.resetSchemaRegistry()
+      instance.resetSchemaRegistry()
       assert.equal(mockSchemas.resetSchemaRegistry.mock.calls.length, 1)
     })
   })


### PR DESCRIPTION
### Fixes #58 

### Update
* Remove unnecessary `await` from library calls that are now synchronous (`init`, `resetSchemaRegistry`, `registerSchema`, `getSchema`)
* Drop `async` from `resetSchemaRegistry()` and `registerSchema()` wrapper methods
* Replace `Promise.allSettled` with synchronous try/catch loop in `registerSchemas()`
* Update JSDoc return types from `Promise<Schema>` to `Schema`

Note: `getSchema()` remains async as it awaits `this._schemasRegistered` (a framework-level Promise)

Depends on https://github.com/cgkineo/adapt-schemas/pull/25

### Testing
1. Run `npm run dev` and verify schemas load without errors
2. Verify schema validation still works via the API
3. Run `npm test` for integration tests