### PR TITLE
Update: Remove absorbed module dependencies

### DIFF
--- a/lib/JsonSchemaModule.js
+++ b/lib/JsonSchemaModule.js
@@ -1,6 +1,5 @@
 import { AbstractModule, App, Hook } from 'adapt-authoring-core'
 import { glob } from 'glob'
-import path from 'path'
 import { Schemas, SchemaError, XSSDefaults } from 'adapt-schemas'
 
 /**
@@ -41,19 +40,9 @@ class JsonSchemaModule extends AbstractModule {
       modifying: true,
       schemaType: 'boolean',
       compile: function () {
-        const doReplace = value => {
-          const app = App.instance
-          return [
-            ['$ROOT', app.rootDir],
-            ['$DATA', app.getConfig('dataDir')],
-            ['$TEMP', app.getConfig('tempDir')]
-          ].reduce((m, [k, v]) => {
-            return m.startsWith(k) ? path.resolve(v, m.replace(k, '').slice(1)) : m
-          }, value)
-        }
         return (value, { parentData, parentDataProperty }) => {
           try {
-            parentData[parentDataProperty] = doReplace(value)
+            parentData[parentDataProperty] = App.instance.config.resolveDirectory(value)
           } catch (e) {}
           return true
         }

--- a/lib/JsonSchemaModule.js
+++ b/lib/JsonSchemaModule.js
@@ -233,8 +233,8 @@ class JsonSchemaModule extends AbstractModule {
    */
   logSchemas () {
     this.log('debug', 'SCHEMAS', Object.keys(this.schemas))
-    this.log('debug', 'SCHEMA_EXTENSIONS', Object.entries(this.schemas).reduce((m, [k, v]) => {
-      if (v.extensions.length) m[k] = v.extensions
+    this.log('debug', 'SCHEMA_EXTENSIONS', Object.entries(this.schemaExtensions).reduce((m, [k, v]) => {
+      if (v?.length) m[k] = v
       return m
     }, {}))
   }

--- a/lib/JsonSchemaModule.js
+++ b/lib/JsonSchemaModule.js
@@ -61,7 +61,6 @@ class JsonSchemaModule extends AbstractModule {
     })
 
     this._schemasRegistered = this.onReady()
-      .then(() => this.app.waitForModule('config', 'errors'))
       .then(() => {
         // Update library options from config
         this._library.options.enableCache = this.getConfig('enableCache')

--- a/package.json
+++ b/package.json
@@ -14,12 +14,8 @@
   },
   "repository": "github:adapt-security/adapt-authoring-jsonschema",
   "dependencies": {
-    "adapt-authoring-core": "^2.0.0",
+    "adapt-authoring-core": "^3.0.0",
     "adapt-schemas": "^3.1.0"
-  },
-  "peerDependencies": {
-    "adapt-authoring-config": "^1.1.4",
-    "adapt-authoring-errors": "^1.1.2"
   },
   "devDependencies": {
     "@adaptlearning/semantic-release-config": "^1.0.0",


### PR DESCRIPTION
### Update

- Remove `adapt-authoring-config` and `adapt-authoring-errors` peerDependencies (now bootstrap libraries in core)
- Remove `waitForModule('config', 'errors')` call — both are loaded before module init
- Bump `adapt-authoring-core` to `^3.0.0`