### PR TITLE
Fix: report the actual missing schema in getSchema errors (fixes #67)

### DIFF
--- a/lib/JsonSchemaModule.js
+++ b/lib/JsonSchemaModule.js
@@ -234,7 +234,7 @@ class JsonSchemaModule extends AbstractModule {
       return this._library.getSchema(schemaName, options)
     } catch (e) {
       if (e instanceof SchemaError && e.code === 'MISSING_SCHEMA') {
-        throw this.app.errors.MISSING_SCHEMA.setData({ schemaName })
+        throw this.app.errors.MISSING_SCHEMA.setData({ schemaName: e.data?.schemaName ?? schemaName })
       }
       throw e
     }


### PR DESCRIPTION
### Fixes #67

### Fix
* Preserve the inner `SchemaError`'s `schemaName` when re-wrapping a `MISSING_SCHEMA` error in `getSchema`. Previously the requested (parent) schema name was always reported, masking which extension was actually missing — e.g. requesting `course` would report `course` missing when the actual culprit was a stale extension reference like `keepScrollPosition-course`.